### PR TITLE
Improvements on Caesar.sdd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     pn/tina.cc
     pn/transition.cc
     pn/unit.cc
+    compress/compress.cc
     )
 
 add_executable(caesar.sdd ${SOURCES})

--- a/src/compress/compress.cc
+++ b/src/compress/compress.cc
@@ -1,0 +1,72 @@
+/******************************************************************************
+Copyright (c) 2019, Hubert GARAVEL
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#include <iostream>
+#include "compress.hh"
+
+using namespace std;
+
+namespace caesar_compress {
+
+/*---------------------------------------------------------------------------*/
+
+compress::compress()
+  : PREVIOUS_CELL('\0'), NB_REPEATED_CELLS(0)
+{}
+
+/*---------------------------------------------------------------------------*/
+
+void compress::dump_compression(char CELL)
+{
+  /* assert (NB_REPEATED_CELLS == 0) <=> (PREVIOUS_CELL == '\0') */
+  /* assert (PREVIOUS_CELL != '\n') */
+
+  if (CELL == PREVIOUS_CELL) {
+    /* assert (PREVIOUS_CELL != '\0') */
+    ++NB_REPEATED_CELLS;
+  } else {
+    /* possibly emptying of the repetition buffer */
+    if (NB_REPEATED_CELLS > 3) {
+      std::cout << "(" << NB_REPEATED_CELLS << ")";
+    } else if (NB_REPEATED_CELLS > 0) {
+      for ( /* nothing */ ; NB_REPEATED_CELLS > 1; --NB_REPEATED_CELLS)
+        printf ("%c", PREVIOUS_CELL);
+    }
+    std::cout << CELL;
+    if (CELL == '\n') {
+      /* particuliar case : end of line */
+      PREVIOUS_CELL = '\0';
+      NB_REPEATED_CELLS = 0;
+    } else {
+      /* case of an ordinary character */
+      PREVIOUS_CELL = CELL;
+      NB_REPEATED_CELLS = 1;
+    }
+  }
+}
+
+} // namespace caesar_compress
+

--- a/src/compress/compress.hh
+++ b/src/compress/compress.hh
@@ -1,0 +1,45 @@
+/******************************************************************************
+Copyright (c) 2019, Hubert GARAVEL
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#ifndef _CAESAR_COMPRESS_
+#define _CAESAR_COMPRESS_
+
+namespace caesar_compress {
+
+class compress
+{
+private:
+  char PREVIOUS_CELL;
+  int NB_REPEATED_CELLS;
+
+public:
+  compress();
+  void dump_compression(char CELL);
+};
+
+} // namespace caesar_compress
+
+#endif // _CAESAR_COMPRESS_

--- a/src/conf/fill_configuration.cc
+++ b/src/conf/fill_configuration.cc
@@ -32,15 +32,15 @@ constexpr auto order_force_str = "order-force";
 constexpr auto order_force_iterations_str = "order-force-iterations";
 
 // Petri net options
-constexpr auto check_safe_net_str = "check-1-safe";
+constexpr auto check_safe_net_str = "check";
 
 // Statistics options
 constexpr auto show_nb_states_str = "show-nb-states";
 constexpr auto show_time_str = "show-time";
 
 // CADP options
-constexpr auto dead_str = "dead";
-constexpr auto unit_str = "unit";
+constexpr auto dead_str = "dead-transitions";
+constexpr auto unit_str = "concurrent-units";
 
 boost::optional<pnmc_configuration>
 fill_configuration(int argc, char** argv)

--- a/src/mc/units/concurrent_units.cc
+++ b/src/mc/units/concurrent_units.cc
@@ -9,6 +9,8 @@
 
 #include "mc/units/concurrent_units.hh"
 
+#include "compress/compress.hh"
+
 namespace pnmc { namespace mc { namespace units {
 
 /*------------------------------------------------------------------------------------------------*/
@@ -304,6 +306,7 @@ compute_concurrent_units( const conf::pnmc_configuration& conf, const pn::net& n
 {
   namespace chrono = std::chrono;
   chrono::time_point<chrono::system_clock> start = chrono::system_clock::now();
+  caesar_compress::compress compressor;
 
   const auto nb_units = net.units().size();
   unsigned int j_end = 1;
@@ -314,14 +317,14 @@ compute_concurrent_units( const conf::pnmc_configuration& conf, const pn::net& n
       if ( i == j or net.places_of_unit(i).empty() or net.places_of_unit(j).empty()
           or net.units_are_related(i, j))
       {
-        std::cout << "0 ";
+        compressor.dump_compression('0');
       }
       else
       {
-        std::cout << (query(net, states, o, i, j) ? "1 " : "0 ");
+        compressor.dump_compression((query(net, states, o, i, j) ? '1' : '0'));
       }
     }
-    std::cout << std::endl;
+    compressor.dump_compression('\n');
   }
 
   chrono::time_point<chrono::system_clock> end = chrono::system_clock::now();

--- a/src/mc/units/worker.cc
+++ b/src/mc/units/worker.cc
@@ -193,10 +193,11 @@ transition_relation( const conf::pnmc_configuration& conf, const order& o
     }
     else if (conf.compute_dead_transitions)
     {
+      // Sink transition : Card(Pre) > 0 and Card(Post) = 0
       // Target the same variable as the pre that is fired just before this fake post.
-      const auto unit = transition.pre.begin()->first;
-
+      const auto unit = net.unit_of_place(transition.pre.begin()->first);
       const auto f = function(o, unit, nopost_live{tindex++, transitions_bitset});
+
       h_t = composition(h_t, sdd::carrier(o, unit, f));
     }
 

--- a/src/mc/units/worker.cc
+++ b/src/mc/units/worker.cc
@@ -162,7 +162,7 @@ transition_relation( const conf::pnmc_configuration& conf, const order& o
     if (transition.post.empty() and transition.pre.empty() and conf.compute_dead_transitions)
     {
       // Empty transition, but we need to increment the transition counter.
-      ++tindex;
+      transitions_bitset[tindex++] = true;
     }
     else if (not transition.post.empty())
     {

--- a/src/mc/units/worker.cc
+++ b/src/mc/units/worker.cc
@@ -16,6 +16,7 @@
 #include "mc/units/sdd.hh"
 #include "mc/units/worker.hh"
 
+#include "compress/compress.hh"
 
 namespace pnmc { namespace mc { namespace units {
 
@@ -289,12 +290,14 @@ const
     std::cout << m.size().template convert_to<long double>() << " states\n";
   }
 
-  if (conf.compute_dead_transitions)
+  if (conf.compute_dead_transitions and net.transitions().size())
   {
+    caesar_compress::compress compressor;
     for (std::size_t i = 0; i < net.transitions().size(); ++i)
     {
-      std::cout << (!transitions_bitset[i]) << "\n";
+      compressor.dump_compression(transitions_bitset[i] ? '0' : '1');
     }
+    compressor.dump_compression('\n');
   }
 
   if (conf.compute_concurrent_units)

--- a/src/parsers/bpn.cc
+++ b/src/parsers/bpn.cc
@@ -341,6 +341,7 @@ bpn(std::istream& in)
     net.add_transition(transition_id);
 
     // Input places.
+    bool is_source_transition = nb_places == 0;
     for (; nb_places > 0; --nb_places)
     {
       unsigned int place_id;
@@ -350,11 +351,17 @@ bpn(std::istream& in)
 
     // Output places.
     in >> sharp(nb_places);
+    is_source_transition &= nb_places > 0;
     for (; nb_places > 0; --nb_places)
     {
       unsigned int place_id;
       in >> uint(place_id);
       net.add_post_place(transition_id, place_id, 1 /* arc valuation */);
+    }
+
+    if (is_source_transition)
+    {
+      throw parse_error("Source transition not allowed: T" + std::to_string(transition_id));
     }
   }
 

--- a/src/pn/transition.cc
+++ b/src/pn/transition.cc
@@ -29,12 +29,12 @@ operator<<(std::ostream& os, const transition& t)
   os << "tr " << t.id;
   for(auto p : t.pre)
   {
-    os << " " << p.first << p.second;
+    os << " (" << p.first << ", " << p.second << ")";
   }
   os << " -> ";
   for(auto p : t.post)
   {
-    os << " " << p.first << p.second;
+    os << " (" << p.first << ", " << p.second << ")";
   }  
   return os;
 }


### PR DESCRIPTION
The behavior of Caesar.bdd evolved through years.
This pull-request backports important changes at the user level:

- The naming of options
- The compression of the dead transitions vector and the concurrent units matrix is now handled

It also provides 2 bug fixes on Caesar.sdd:

- Empty transitions are not marked as dead anymore
- A bug affected sink transitions, an index number issue

Finally, it does 2 minor improvements:

- If a NUPN contains a source transition, it will always be unsafe. So the file will be rejected by the parser, with an appropriate error message
- For debugging purpose, the '<<' method of transitions is not ambiguous anymore